### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "dotenv": "^17.2.0",
     "express": "^4.18.2",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/server/node-build.ts
+++ b/server/node-build.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { createServer } from "./index";
 import * as express from "express";
+import rateLimit from "express-rate-limit";
 
 const app = createServer();
 const port = process.env.PORT || 3000;
@@ -8,6 +9,15 @@ const port = process.env.PORT || 3000;
 // In production, serve the built SPA files
 const __dirname = import.meta.dirname;
 const distPath = path.join(__dirname, "../spa");
+
+// Rate limiter: max 100 requests per 15 minutes per IP
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+// Apply rate limiter to all requests
+app.use(limiter);
 
 // Serve static files
 app.use(express.static(distPath));


### PR DESCRIPTION
Potential fix for [https://github.com/ARSTRA/builder-neon-field/security/code-scanning/1](https://github.com/ARSTRA/builder-neon-field/security/code-scanning/1)

To fix the problem, we should add a rate-limiting middleware to the Express application to limit the number of requests a client can make in a given time window. The best way to do this is to use the well-known `express-rate-limit` package. We should import this package, configure a rate limiter (e.g., 100 requests per 15 minutes per IP), and apply it to the relevant routes. Since both the static file serving and the catch-all route handler perform file system access, the rate limiter should be applied to all requests (using `app.use(limiter)` before the static and catch-all routes). This change should be made in `server/node-build.ts`. We need to add the import for `express-rate-limit`, create the limiter, and apply it as middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
